### PR TITLE
Updated Readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Utility to update or install the Appgate sdpctl utility on macOS (https://github
 
 ### Install
 ```
-mv ~/Downloads/sdpctl_update.bin ~/Scripts/sdpctlt_update.sh
-chmod 644 sdpctl_update.sh
+mv ~/Downloads/sdpctl_update.sh ~/Scripts/sdpctl_update.sh
+chmod 744 sdpctl_update.sh
 ```
 
 ### Create Alias
@@ -14,7 +14,7 @@ Add alias to ~/.zshrc or ~/.bashrc
 sudo nano ~/.zshrc
 ```
 ```
-alias sdpctl_update='~/Scripts/sdpctl_update.sh'
+alias sdpctl_update="~/Scripts/sdpctl_update.sh"
 ```
 
 ### Run


### PR DESCRIPTION
Line 6 changed .bin to .sh since .bin file doesn't exist
Line 6 removed "t" typo in script name
Line 7 changed permissions to 744 to allow execute so it can run. 
Line 17 changed single quotes to double quotes because when you copy
    that line it doesn't work properly in the .zshrc file.